### PR TITLE
[FIX] vat report: add checks from administration

### DIFF
--- a/l10n_be_mis_reports/data/mis_report_vat.xml
+++ b/l10n_be_mis_reports/data/mis_report_vat.xml
@@ -94,7 +94,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_46</field>
       <field name="description">Grid 46</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.id', 'in', (ref('l10n_be.tax_tag_46L').id), ref('l10n_be.tax_tag_46T').id)), '|', ('invoice_id.type', '=', 'out_invoice'), ('debit', '=', 0)]</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.id', '=', ref('l10n_be.tax_tag_46L').id), '|', ('invoice_id.type', '=', 'out_invoice'), ('debit', '=', 0)]-bal[][('tax_ids.tag_ids.id', '=', ref('l10n_be.tax_tag_46T').id), '|', ('invoice_id.type', '=', 'out_invoice'), ('debit', '=', 0)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
@@ -391,61 +391,61 @@
       <field name="style_id" ref="mis_report_style_l10n_be_2"/>
       <field name="sequence">900</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_vat_control_85">
+    <record model="mis.report.kpi" id="mis_report_vat_control_T">
       <field name="report_id" ref="mis_report_vat"/>
-      <field name="name">ctrl_85</field>
-      <field name="description">Control Grid 85: [85] x 0.21 >= [63]</field>
-      <field name="expression">u'✔' if round(grid_85*0.21, 2) >= round(grid_63, 2) else u'✘'</field>
+      <field name="name">ctrl_T</field>
+      <field name="description">Control T: [85] x 0.21 >= [63]</field>
+      <field name="expression">u'✔' if abs(grid_85*0.21 - grid_63) &lt; 62 else u'✘'</field>
       <field name="type">str</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
       <field name="sequence">901</field>
     </record>
-    <record model="mis.report.kpi" id="mis_report_vat_control_49">
+    <record model="mis.report.kpi" id="mis_report_vat_control_U">
       <field name="report_id" ref="mis_report_vat"/>
-      <field name="name">ctrl_49</field>
-      <field name="description">Control Grid 49: [49] x 0.21 >= [64]</field>
-      <field name="expression">u'✔' if round(grid_49*0.21, 2) >= round(grid_64, 2) else u'✘'</field>
+      <field name="name">ctrl_U</field>
+      <field name="description">Control U: [49] x 0.21 >= [64]</field>
+      <field name="expression">u'✔' if abs(grid_49*0.21 - grid_64) &lt; 62 else u'✘'</field>
       <field name="type">str</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
       <field name="sequence">902</field>
     </record>
-     <record model="mis.report.kpi" id="mis_report_vat_control_54">
+     <record model="mis.report.kpi" id="mis_report_vat_control_O">
       <field name="report_id" ref="mis_report_vat"/>
-      <field name="name">ctrl_54</field>
-      <field name="description">Control Grid 54: [01] x 0.06 + [02] x 0.12 + [03] x 0.21 >= [54]</field>
+      <field name="name">ctrl_O</field>
+      <field name="description">Control O: [01] x 0.06 + [02] x 0.12 + [03] x 0.21 >= [54]</field>
       <field name="expression">u'✔' if abs(grid_01*0.6 + grid_02*0.12 + grid_03*0.21 - grid_54) &lt; 62 else u'✘'</field>
       <field name="type">str</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
       <field name="sequence">903</field>
     </record>
-     <record model="mis.report.kpi" id="mis_report_vat_control_55">
+     <record model="mis.report.kpi" id="mis_report_vat_control_P">
       <field name="report_id" ref="mis_report_vat"/>
-      <field name="name">ctrl_55</field>
-      <field name="description">Control Grid 55: ([84] + [86] + [88]) x 0.21 >= [55]</field>
-      <field name="expression">u'✔' if round((grid_84 + grid_86 + grid_88)*0.21, 2) >= round(grid_55, 2) else u'✘'</field>
+      <field name="name">ctrl_P</field>
+      <field name="description">Control P: ([84] + [86] + [88]) x 0.21 >= [55]</field>
+      <field name="expression">u'✔' if abs((grid_84 + grid_86 + grid_88)*0.21 - grid_55) &lt; 62 else u'✘'</field>
       <field name="type">str</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
       <field name="sequence">904</field>
     </record>
-     <record model="mis.report.kpi" id="mis_report_vat_control_87">
+     <record model="mis.report.kpi" id="mis_report_vat_control_Q">
       <field name="report_id" ref="mis_report_vat"/>
-      <field name="name">ctrl_87</field>
-      <field name="description">Control Grid 87: ([85] + [87]) x 0.21 >= [56] + [57]</field>
-      <field name="expression">u'✔' if round((grid_85 + grid_87)*0.21, 2) >= round(grid_56 + grid_57, 2) else u'✘'</field>
+      <field name="name">ctrl_Q</field>
+      <field name="description">Control Q: ([85] + [87]) x 0.21 >= [56] + [57]</field>
+      <field name="expression">u'✔' if abs((grid_85 + grid_87)*0.21 - (grid_56 + grid_57)) &lt; 62 else u'✘'</field>
       <field name="type">str</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>
       <field name="sequence">905</field>
     </record>
-     <record model="mis.report.kpi" id="mis_report_vat_control_59">
+    <record model="mis.report.kpi" id="mis_report_vat_control_S">
       <field name="report_id" ref="mis_report_vat"/>
-      <field name="name">ctrl_59</field>
-      <field name="description">Control Grid 59: ([81] + [82] + [83] + [84] + [85]) x 0.5 >= [59]</field>
-      <field name="expression">u'✔' if round((grid_81 + grid_82 + grid_83 + grid_84 + grid_85)*0.5, 2) >= round(grid_59, 2) else u'✘'</field>
+      <field name="name">ctrl_S</field>
+      <field name="description">Control S: ([81]+[82]+[83]+[84]+[85])*0.5>[59]</field>
+      <field name="expression">u'✔' if (grid_81 + grid_82 + grid_83 + grid_84 + grid_85)*0.5 > grid_59 else u'✘'</field>
       <field name="type">str</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>

--- a/l10n_be_mis_reports/data/mis_report_vat.xml
+++ b/l10n_be_mis_reports/data/mis_report_vat.xml
@@ -94,7 +94,7 @@
       <field name="report_id" ref="mis_report_vat"/>
       <field name="name">grid_46</field>
       <field name="description">Grid 46</field>
-      <field name="expression">-bal[][('tax_ids.tag_ids.id', '=', ref('l10n_be.tax_tag_46L').id), '|', ('invoice_id.type', '=', 'out_invoice'), ('debit', '=', 0)]-bal[][('tax_ids.tag_ids.id', '=', ref('l10n_be.tax_tag_46T').id), '|', ('invoice_id.type', '=', 'out_invoice'), ('debit', '=', 0)]</field>
+      <field name="expression">-bal[][('tax_ids.tag_ids.id', 'in', (ref('l10n_be.tax_tag_46L').id, ref('l10n_be.tax_tag_46T').id)), '|', ('invoice_id.type', '=', 'out_invoice'), ('debit', '=', 0)]</field>
       <field name="type">num</field>
       <field name="compare_method">pct</field>
       <field name="style_id" ref="mis_report_style_l10n_be_3"/>

--- a/l10n_be_mis_reports/i18n/fr.po
+++ b/l10n_be_mis_reports/i18n/fr.po
@@ -214,47 +214,47 @@ msgstr "Commandes en cours d'exécution [37]"
 #. module: l10n_be_mis_reports
 #: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_control
 msgid "Control"
-msgstr ""
+msgstr "Contrôles"
 
 #. module: l10n_be_mis_reports
 #: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_control_60
 msgid "Control 60 vs [81]"
-msgstr ""
+msgstr "Contrôle 60 vs [81]"
 
 #. module: l10n_be_mis_reports
 #: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_control_70
 msgid "Control 70 vs Cadre II"
-msgstr ""
+msgstr "Contrôle 70 vs Cadre II"
 
 #. module: l10n_be_mis_reports
-#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_control_49
-msgid "Control Grid 49: [49] x 0.21 >= [64]"
-msgstr ""
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_control_U
+msgid "Control U: [49] x 0.21 >= [64]"
+msgstr "Contrôle U: [49] x 0.21 >= [64]"
 
 #. module: l10n_be_mis_reports
-#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_control_54
-msgid "Control Grid 54: [01] x 0.06 + [02] x 0.12 + [03] x 0.21 >= [54]"
-msgstr ""
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_control_O
+msgid "Control O: [01] x 0.06 + [02] x 0.12 + [03] x 0.21 >= [54]"
+msgstr "Contrôle O: [01] x 0.06 + [02] x 0.12 + [03] x 0.21 >= [54]"
 
 #. module: l10n_be_mis_reports
-#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_control_55
-msgid "Control Grid 55: ([84] + [86] + [88]) x 0.21 >= [55]"
-msgstr ""
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_control_P
+msgid "Control P: ([84] + [86] + [88]) x 0.21 >= [55]"
+msgstr "Contrôle P: ([84] + [86] + [88]) x 0.21 >= [55]"
 
 #. module: l10n_be_mis_reports
-#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_control_59
-msgid "Control Grid 59: ([81] + [82] + [83] + [84] + [85]) x 0.5 >= [59]"
-msgstr ""
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_control_S
+msgid "Control S: ([81] + [82] + [83] + [84] + [85]) x 0.5 >= [59]"
+msgstr "Contrôle S: ([81] + [82] + [83] + [84] + [85]) x 0.5 >= [59]"
 
 #. module: l10n_be_mis_reports
-#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_control_85
-msgid "Control Grid 85: [85] x 0.21 >= [63]"
-msgstr ""
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_control_T
+msgid "Control T: [85] x 0.21 >= [63]"
+msgstr "Contrôle T: [85] x 0.21 >= [63]"
 
 #. module: l10n_be_mis_reports
-#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_control_87
-msgid "Control Grid 87: ([85] + [87]) x 0.21 >= [56] + [57]"
-msgstr ""
+#: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_vat_control_Q
+msgid "Control Q: ([85] + [87]) x 0.21 >= [56] + [57]"
+msgstr "Contrôle Q: ([85] + [87]) x 0.21 >= [56] + [57]"
 
 #. module: l10n_be_mis_reports
 #: model:mis.report.kpi,description:l10n_be_mis_reports.mis_report_bs_fr177


### PR DESCRIPTION
This PR aims at improving the controls done at the end of the VAT report, in order to be compliant with the fiscal administration:
https://eservices.minfin.fgov.be/intervat/static/help/FR/helpfile.htm#regles_de_validation_d_une_declaration.htm

The checks added are: O, P ,Q ,S, T, U

For ther other checks, I don't know how to technically add them. The list is in attachment with my comments for each check:
[VAT-checks_in_odoo.xlsx](https://github.com/acsone/l10n-belgium/files/2254240/VAT-checks_in_odoo.xlsx)

